### PR TITLE
Removal of much of the readme contents...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,7 @@ References
 
 * `http://www.graphviz.org <http://www.graphviz.org>`_
 * `GraphViz Java API Loria <http://www.loria.fr/~szathmar/off/projects/java/GraphVizAPI/index.php>`_
+* `Spark Java Framework <http://www.sparkjava.com/>`_
 
 Author
 ------


### PR DESCRIPTION
I have made a wiki for Khansa Diagram Creator. It seems like the wiki is not transferred over the pull request.

My suggestion is to:
[ ]  make a wiki
[ ]  check out the following: https://github.com/nostra/khanasadiagramcreator/wiki
[ ] copy contents to the correct Khanasa wiki
[ ] correct the links
